### PR TITLE
Target #post instead of header

### DIFF
--- a/require-featured-image-on-edit.js
+++ b/require-featured-image-on-edit.js
@@ -26,7 +26,7 @@ jQuery(document).ready(function($) {
 
 	function createMessageAreaIfNeeded() {
 		if ($('body').find("#nofeature-message").length === 0) {
-			$('h1, h2').after('<div id="nofeature-message"></div>');
+			$('#post').before('<div id="nofeature-message"></div>');
 	    }
 	}
 


### PR DESCRIPTION
Incase there are other `<h1>` or `<h2>` tags on the page, we could use $('h1, h2').first() but targeting #post is possibly more reliable and future proof.

Seems as though the #post has been used as far back as v1.5 https://github.com/WordPress/WordPress/blob/1.5-branch/wp-admin/edit-form-advanced.php