### PR TITLE
Fix issue with size checking of images that have been downsized through Wordpress.

### DIFF
--- a/require-featured-image-on-edit.js
+++ b/require-featured-image-on-edit.js
@@ -12,8 +12,11 @@ jQuery(document).ready(function($) {
 	}
 
 	function passedImageIsTooSmall($img) {
-		var input = $img[0].src;
-		var pathToImage = input.replace(/-\d+[Xx]\d+\./g, ".");
+		var pathToImage = $img.data('rfiimgsrc');
+		if (!pathToImage) {
+			var input = $img[0].src;
+			pathToImage = input.replace(/-\d+[Xx]\d+\./g, ".");
+		}
 		var featuredImage = new Image();
 		featuredImage.src = pathToImage;
 		return featuredImage.width < passedFromServer.width || featuredImage.height < passedFromServer.height;
@@ -37,7 +40,7 @@ jQuery(document).ready(function($) {
 	    }
 	}
 
-    function detectWarnFeaturedImage() {
+	function detectWarnFeaturedImage() {
 		if (checkImageReturnWarningMessageOrEmpty()) {
 			disablePublishAndWarn(checkImageReturnWarningMessageOrEmpty());
 		} else {

--- a/require-featured-image.php
+++ b/require-featured-image.php
@@ -139,3 +139,11 @@ function rfi_get_warning_message() {
         $minimum_size['height']
     );
 }
+
+add_action( 'admin_post_thumbnail_html', 'rfi_admin_post_thumbnail_html', 10, 3 );
+function rfi_admin_post_thumbnail_html($html, $post_id, $thumbnail_id) {
+	if ($thumbnail_id && $image_meta = wp_get_attachment_image_src( $thumbnail_id, 'full' )) {
+		$html = preg_replace('/<img /', '<img data-rfiimgsrc="'.esc_attr($image_meta[0]).'" ', $html);
+	}
+	return $html;
+}


### PR DESCRIPTION
Previously the size of the original image was being used for the size check in Javascript. Now the URL of resized image is injected as a data attribute into the admin post thumbnail html and then the rfi Javascript uses that URL (or fallbacks to the old behaviour of stripping the thumbnail size name from the image URL).